### PR TITLE
[Test] Weakness event about Dad class based on clues of script

### DIFF
--- a/test/net/sourceforge/kolmafia/session/DadManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/DadManagerTest.java
@@ -96,4 +96,27 @@ public class DadManagerTest {
     }
   }
 
+  @Test
+  public void canSetWeakness10BeNone() {
+    int targetIndex = 10;
+    String[] clueTextList = {
+      "",
+      "chaotic",
+      "shamble",
+      "putrescent",
+      "darkness",
+      "wobbles",
+      "suddenly",
+      "64",
+      "mind",
+      "3",
+      "head"
+    };
+    String responseText = setResponseText(clueTextList);
+
+    DadManager.solve(responseText);
+
+    Element noneWeakness = DadManager.weakness(targetIndex);
+    assertEquals(Element.NONE, noneWeakness);
+  }
 }

--- a/test/net/sourceforge/kolmafia/session/DadManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/DadManagerTest.java
@@ -16,6 +16,34 @@ public class DadManagerTest {
     Preferences.reset("DadManagerTest");
   }
 
+  private String setResponseText(String[] clueTextList) {
+    return "You shake your head and look above the tank, at the window into space. "
+        + clueTextList[1]
+        + " forms "
+        + clueTextList[2]
+        + " in the darkness, each more "
+        + clueTextList[3]
+        + " than the last. "
+        + "The "
+        + clueTextList[4]
+        + " "
+        + clueTextList[5]
+        + ", "
+        + clueTextList[6]
+        + " revealing "
+        + clueTextList[7]
+        + "-dimensional monstrosities.. No. "
+        + "Look again. There is nothing. Are your "
+        + clueTextList[8]
+        + " betraying you? "
+        + "As if on cue, "
+        + clueTextList[9]
+        + "-sided triangles materialize and then disappear. "
+        + "So impossible that your "
+        + clueTextList[10]
+        + " throbs.";
+  }
+
   @Test
   public void canSearchElementName() {
     Element validElement = Element.SLEAZE;
@@ -28,6 +56,44 @@ public class DadManagerTest {
     Element validElement = Element.SLEAZE;
     String elementSpell = DadManager.elementToSpell(validElement);
     assertEquals("Unknown", elementSpell);
+  }
+
+  @Test
+  public void canSetAllWeaknessWhenValidResponseText() {
+    String[] clueTextList = {
+      "",
+      "horrifying",
+      "swim",
+      "awful",
+      "space",
+      "cracks open",
+      "suddenly",
+      "32",
+      "eyes",
+      "3",
+      "stomach"
+    };
+    String validResponseText = setResponseText(clueTextList);
+    Element[] weaknessList = {
+      Element.NONE,
+      Element.SPOOKY,
+      Element.PHYSICAL,
+      Element.COLD,
+      Element.PHYSICAL,
+      Element.COLD,
+      Element.SLEAZE,
+      Element.SLEAZE,
+      Element.SPOOKY,
+      Element.NONE,
+      Element.PHYSICAL
+    };
+
+    DadManager.solve(validResponseText);
+
+    int index = 0;
+    for (DadManager.Element elementalWeakness : DadManager.ElementalWeakness) {
+      assertEquals(weaknessList[index++], elementalWeakness);
+    }
   }
 
 }

--- a/test/net/sourceforge/kolmafia/session/DadManagerTest.java
+++ b/test/net/sourceforge/kolmafia/session/DadManagerTest.java
@@ -1,0 +1,33 @@
+package net.sourceforge.kolmafia.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.sourceforge.kolmafia.KoLCharacter;
+import net.sourceforge.kolmafia.preferences.Preferences;
+import net.sourceforge.kolmafia.session.DadManager.Element;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DadManagerTest {
+
+  @BeforeEach
+  public void beforeEach() {
+    KoLCharacter.reset("DadManagerTest");
+    Preferences.reset("DadManagerTest");
+  }
+
+  @Test
+  public void canSearchElementName() {
+    Element validElement = Element.SLEAZE;
+    String elementName = DadManager.elementToName(validElement);
+    assertEquals("sleaze", elementName);
+  }
+
+  @Test
+  public void canReturnUnknownWhenCharacterHasNoSkill() {
+    Element validElement = Element.SLEAZE;
+    String elementSpell = DadManager.elementToSpell(validElement);
+    assertEquals("Unknown", elementSpell);
+  }
+
+}


### PR DESCRIPTION
### Issue
- Absence of sole test code for `DadManager`
- The need to test whether Dad's weaknesses are invoked for scripts containing clues
<img width="688" alt="image" src="https://github.com/kimty103/kolmafia/assets/79911816/9dea8a33-5ce3-48d5-951a-8a0ea0a6e5a8">


### Check
- [x] Execute `Gradle run` and clear
- [x] Execute Test code and clear
- [x] Apply `Gradle spotlessApply`

### Task
- [x] Preprocess and register mock KOLCharacter
- [x] Create a function that generates a script based on 10 clues (test input)
- [x] Write a test for `canSearchElementName()`, `canReturnUnknownWhenCharacterHasNoSkill()` function.
- [x] Write a test for `canSetAllWeaknessWhenValidResponseText()` function.
- [x] Write a test for `canSetWeakness10BeNone()` function.

### Description
Write a test code to ensure access to 7 elements of Dad.
Write a test code for identifying weaknesses of Dad based on 10 clues in the script.
```
Line Coverage 6% -> 85%
```
<img width="731" alt="image" src="https://github.com/kimty103/kolmafia/assets/79911816/d382170e-a48d-49db-be8e-fba94b13dad0">


